### PR TITLE
wrap parameters in call_limit

### DIFF
--- a/packages/tronwrap/index.js
+++ b/packages/tronwrap/index.js
@@ -96,9 +96,18 @@ function init(options) {
         callSend = /payable/.test(val.stateMutability) ? 'send' : 'call'
       }
     })
+
+    var callValue = option.call_value || 0;
+    var feeLimit = option.fee_limit;
+    if(typeof option.call_limit !== 'undefined' && option.call_limit){
+      callValue = option.call_limit.call_value || callValue;
+      feeLimit = option.call_limit.fee_limit || feeLimit;
+      console.log(callValue);
+    }
+    
     myContract[option.methodName](...option.args)[callSend]({
-      fee_limit: option.fee_limit,
-      call_value: option.call_value || 0,
+      fee_limit: feeLimit,
+      call_value: callValue,
     })
       .then(function (res) {
         // if (!Array.isArray(res)) {


### PR DESCRIPTION
for setting dynamic call_value for testing the contract, I found that those parameters like call_value and fee_limit are wrapped in a key called call_limit, therefore, if we try to set a dynamic call_value during the test: 
    meta.call('sendCoin', [account_two, amount], {call_value:100});
it is gonna wrap the call_value in the call_limit.

I modify the tronwrap/index.js so it will use the call_value and fee_limit we set in the test. if they are not provided, it will use those default values provided in tronbox.js