### PR TITLE
Fix triggerContract when from is not passed

### DIFF
--- a/packages/tronbox/package.json
+++ b/packages/tronbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tronbox",
   "namespace": "tronprotocol",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "TronBox - Simple development framework for tronweb",
   "dependencies": {
     "mocha": "^4.1.0",

--- a/packages/tronwrap/index.js
+++ b/packages/tronwrap/index.js
@@ -131,7 +131,8 @@ function init(options) {
         callSend = /payable/.test(val.stateMutability) ? 'send' : 'call'
       }
     })
-    if (!option.methodArgs) option.methodArgs = {}
+    option.methodArgs || (option.methodArgs = {})
+    option.methodArgs.from || (option.methodArgs.from = this._accounts[0])
 
     var privateKey
     if (callSend === 'send' && option.methodArgs.from && this._accounts) {

--- a/packages/truffle-core/lib/testing/testrunner.js
+++ b/packages/truffle-core/lib/testing/testrunner.js
@@ -9,6 +9,8 @@ var _ = require("lodash");
 var async = require("async");
 var fs = require("fs");
 var TronWrap = require('tronwrap');
+var TronWeb = require("../../../tronwrap/tron-web/dist/TronWeb.node");
+var waitForTransactionReceipt = require('./waitForTransactionReceipt');
 
 function TestRunner(options) {
   options = options || {};
@@ -30,7 +32,15 @@ function TestRunner(options) {
   this.initial_snapshot = null;
   this.known_events = {};
   this.tronwrap = TronWrap();
-  global.tronWeb = TronWrap();
+
+  global.tronWeb = new TronWeb(
+    this.tronwrap.fullNode,
+    this.tronwrap.solidityNode,
+    this.tronwrap.eventServer,
+    this.tronwrap.privateKey
+  )
+
+  global.waitForTransactionReceipt = waitForTransactionReceipt(tronWeb)
 
   // For each test
   this.currentTestStartBlock = null;

--- a/packages/truffle-core/lib/testing/waitForTransactionReceipt.js
+++ b/packages/truffle-core/lib/testing/waitForTransactionReceipt.js
@@ -1,0 +1,29 @@
+// thanks Xavier Leprêtre
+// https://gist.github.com/xavierlepretre/88682e871f4ad07be4534ae560692ee6
+
+waitForTransactionReceipt = (tronWeb) => (txHash = false, interval = 500) => {
+  const transactionReceiptAsync = (resolve, reject) => {
+    tronWeb.trx.getTransactionInfo(txHash, (error, receipt) => {
+      if (error) {
+        reject(error);
+      } else if (!receipt || JSON.stringify(receipt) === '{}') {
+        setTimeout(
+          () => transactionReceiptAsync(resolve, reject),
+          interval
+        );
+      } else {
+        resolve(receipt);
+      }
+    });
+  };
+  if (Array.isArray(txHash)) {
+    return Promise.all(txHash.map(
+      oneTxHash => waitForTransactionReceipt(oneTxHash, interval)));
+  } else if (typeof txHash === "string") {
+    return new Promise(transactionReceiptAsync);
+  } else {
+    throw new Error("Invalid Type: " + txHash);
+  }
+}
+
+module.exports = waitForTransactionReceipt


### PR DESCRIPTION
In some cases the from address is not passed during tests. If so, we tell tronwrap to use`accounts[0]`, as expected.

This also adds a new special function to be used during tests: `waitForTransactionReceipt`. 
It will wait until a transaction has been mined.

Also, the instance of `tronWeb` provided during tests is now clean (before was a tronWrap instance).