### PR TITLE
Using tronbox.js::fullHost if present, instead of fullNode, solidityN…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@
 - Windows, Linux, or Mac OS X
 
 ## Features
-1. Initialize a Customer Tron-Box Project<br>
+Initialize a Customer Tron-Box Project<br>
 `tronbox init`
 <br>
 
-2. Download a dApp, ex: metacoin-box<br>
+Download a dApp, ex: metacoin-box<br>
 `tronbox unbox metacoin`
 <br>
 
-3. Contract Compiler<br>
+Contract Compiler<br>
 `tronbox compile`
 
 <br>
@@ -30,7 +30,62 @@ Optionally, you can select: <br>
 --network save results to a specific host network<br>
 <br>
 
-## 4. Contract Migration<br>
+## Configuration
+To use TronBox, your dApp has to have a file `tronbox.js` in the source root. This special files, tells TronBox how to connect to nodes and event server, and passes some special parameters, like the default private key. This is an example of `tronbox.js`:
+```
+module.exports = {
+  networks: {
+    development: {
+// For trontools/quickstart docker image
+      privateKey: 'da146374a75310b9666e834ee4ad0866d6f4035967bfc76217c5a495fff9f0d0',
+      consume_user_resource_percent: 30,
+      fee_limit: 100000000,
+      fullNode: "http://127.0.0.1:8090",
+      solidityNode: "http://127.0.0.1:8091",
+      eventServer: "http://127.0.0.1:8092",
+      network_id: "*"
+    },
+    mainnet: {
+// Don't put your private key here, pass it using an env variable, like:
+// PK=da146374a75310b9666e834ee4ad0866d6f4035967bfc76217c5a495fff9f0d0 tronbox migrate --network mainnet
+      privateKey: process.env.PK,
+      consume_user_resource_percent: 30,
+      fee_limit: 100000000,
+      fullNode: "https://api.trongrid.io",
+      solidityNode: "https://api.trongrid.io",
+      eventServer: "https://api.trongrid.io",
+      network_id: "*"
+    }
+  }
+};
+```
+Starting from TronBox 2.1.9, if you are connecting to the same host for full and solidity nodes, and event server, you can set just `fullHost`:
+```
+module.exports = {
+  networks: {
+    development: {
+// For trontools/quickstart docker image
+      privateKey: 'da146374a75310b9666e834ee4ad0866d6f4035967bfc76217c5a495fff9f0d0',
+      consume_user_resource_percent: 30,
+      fee_limit: 100000000,
+      fullHost: "http://127.0.0.1:9090",
+      network_id: "*"
+    },
+    mainnet: {
+// Don't put your private key here, pass it using an env variable, like:
+// PK=da146374a75310b9666e834ee4ad0866d6f4035967bfc76217c5a495fff9f0d0 tronbox migrate --network mainnet
+      privateKey: process.env.PK,
+      consume_user_resource_percent: 30,
+      fee_limit: 100000000,
+      fullHost: "https://api.trongrid.io",
+      network_id: "*"
+    }
+  }
+};
+```
+Notice that the example above uses Tron Quickstart >= 1.1.16, which exposes a mononode on port 9090.
+
+## Contract Migration<br>
 `tronbox migrate`
 <br>
 
@@ -38,7 +93,7 @@ This command will invoke all migration scripts within the migrations directory. 
 
 `tronbox migrate --reset`
 <br>
-## 5. Start Console<br>
+## Start Console<br>
 This will use the default network to start a console. It will automatically connect to a TVM client. You can use `--network` to change this. <br>
 
 `tronbox console`<br>
@@ -54,7 +109,7 @@ The console supports the `tronbox` command. For example, you can invoke `migrate
 
 3. Every returned command's promise will automatically be logged. There is no need to use `then()`, which simplifies the command.<br>
 
-## 6. Testing<br>
+## Testing<br>
 
 To carry out the test, run the following command:<br>
 

--- a/packages/tronbox/package.json
+++ b/packages/tronbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tronbox",
   "namespace": "tronprotocol",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "TronBox - Simple development framework for tronweb",
   "dependencies": {
     "mocha": "^4.1.0",

--- a/packages/tronwrap/index.js
+++ b/packages/tronwrap/index.js
@@ -45,9 +45,9 @@ function init(options) {
   }
 
   TronWrap.prototype = new _TronWeb(
-    options.fullNode,
-    options.solidityNode,
-    options.eventServer,
+    options.fullHost || options.fullNode,
+    options.fullHost || options.solidityNode,
+    options.fullHost || options.eventServer,
     options.privateKey
   );
 

--- a/packages/truffle-config/index.js
+++ b/packages/truffle-config/index.js
@@ -17,6 +17,7 @@ function Config(truffle_directory, working_directory, network) {
     consume_user_resource_percent:30,
     from: null,
     privateKey:null,
+    fullHost:null,
     fullNode: null,
     eventServer: null,
     solidityNode: null,
@@ -30,6 +31,7 @@ function Config(truffle_directory, working_directory, network) {
     networks: {},
     verboseRpc: false,
     privateKey:null,
+    fullHost:null,
     fullNode: null,
     solidityNode: null,
     eventServer: null,
@@ -162,6 +164,18 @@ function Config(truffle_directory, working_directory, network) {
       },
       set: function (val) {
         throw new Error("Don't set config.fullNode directly. Instead, set config.networks and then config.networks[<network name>].fullNode")
+      }
+    },
+    fullHost: {
+      get: function () {
+        try {
+          return self.network_config.fullHost;
+        } catch (e) {
+          return default_tx_values.fullHost;
+        }
+      },
+      set: function (val) {
+        throw new Error("Don't set config.fullHost directly. Instead, set config.networks and then config.networks[<network name>].fullHost")
       }
     },
     solidityNode: {


### PR DESCRIPTION
Since TronQuickstart 1.1.16+ and TronGrid expose all the nodes and the event server on the same host and port, this version simplifies the configuration in `tronbox.js`. Look at this example:
```
module.exports = {
  networks: {
    shasta: {
      privateKey: 'da146374a75310b9666e834ee4ad0866d6f4035967bfc76217c5a495fff9f0d0',
      consume_user_resource_percent: 10,
      fee_limit: 100000000,
      fullHost: "https://api.shasta.trongrid.io",
      network_id: "*"
    },
    development: {
      privateKey: 'da146374a75310b9666e834ee4ad0866d6f4035967bfc76217c5a495fff9f0d0',
      consume_user_resource_percent: 10,
      fee_limit: 90000000,
      fullHost: "http://127.0.0.1:9090",
      network_id: "*"
    }
  }
};

```
TronBox remains compatible with previous settings.