### PR TITLE
When a smart contract deploy fails...

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ yarn bootstrap
 
 ## Recent history
 
+__2.3.0__
+When a smart contract deploy fails, the error shows the url to get info about the failed transaction.
 
 __2.2.5__
 False alarm and reverse back for origin_energy_limit check.

--- a/packages/tronbox/package.json
+++ b/packages/tronbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tronbox",
   "namespace": "tronprotocol",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "description": "TronBox - Simple development framework for tronweb",
   "dependencies": {
     "mocha": "^4.1.0",


### PR DESCRIPTION
When a smart contract deploy fails, the error shows the url to get info about the failed transaction.

For example:
<img width="841" alt="screen shot 2018-12-12 at 3 23 25 pm" src="https://user-images.githubusercontent.com/108464/49905294-f3a73e80-fe21-11e8-9390-e6a9f1456461.png">
