### PR TITLE
Fix code property of undefined result

### DIFF
--- a/packages/tronbox/package.json
+++ b/packages/tronbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tronbox",
   "namespace": "tronprotocol",
-  "version": "2.3.12",
+  "version": "2.3.13",
   "description": "TronBox - Simple development framework for tronweb",
   "dependencies": {
     "mocha": "^4.1.0",

--- a/packages/tronwrap/index.js
+++ b/packages/tronwrap/index.js
@@ -209,6 +209,10 @@ function init(options, extraOptions) {
       signedTransaction = await tronWrap.trx.sign(transaction, privateKey)
       const result = await tronWrap.trx.sendRawTransaction(signedTransaction)
 
+      if(!result || typeof result !== 'object') {
+        return Promise.reject(`Error while broadcasting the transaction to create the contract ${options.name}. Most likely, the creator has either insufficient bandwidth or energy.`)
+      }
+
       if(result.code) {
         return Promise.reject(`${result.code} (${tronWrap.toUtf8(result.message)}) while broadcasting the transaction to create the contract ${options.name}`)
       }


### PR DESCRIPTION
Sometimes java-tron does not return a result when a transaction is broadcasted. Most likely this is caused not insufficient bandwidh or energy.
